### PR TITLE
[feat] ProductCurrency 변경

### DIFF
--- a/src/main/java/co/invest72/financial_product/presentation/dto/response/ProductCurrency.java
+++ b/src/main/java/co/invest72/financial_product/presentation/dto/response/ProductCurrency.java
@@ -12,9 +12,13 @@ import lombok.Getter;
 @EqualsAndHashCode
 public class ProductCurrency {
 	private String code;
+	private String country;
 	private String name;
 
 	public static ProductCurrency from(Currency currency) {
-		return new ProductCurrency(currency.getCode(), currency.getName());
+		String fullName = currency.getName();
+		String country = fullName.split(" ")[0];
+		String name = fullName.split(" ")[1];
+		return new ProductCurrency(currency.getCode(), country, name);
 	}
 }

--- a/src/main/java/co/invest72/money/domain/Currency.java
+++ b/src/main/java/co/invest72/money/domain/Currency.java
@@ -13,6 +13,11 @@ public final class Currency {
 	private final String code;
 	private final String name;
 
+	/**
+	 * 통화 객체 생성
+	 * @param code 통화 코드, 예: "KRW", "USD"
+	 * @param name 나라명 + 단위 이름, 예: "한국 원", "미국 달러"
+	 */
 	private Currency(String code, String name) {
 		String normalizedCode = Objects.requireNonNull(code).trim().toUpperCase();
 		validate(normalizedCode);

--- a/src/test/java/co/invest72/financial_product/presentation/FinancialProductCalculationRestControllerTest.java
+++ b/src/test/java/co/invest72/financial_product/presentation/FinancialProductCalculationRestControllerTest.java
@@ -21,7 +21,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
-import co.invest72.money.domain.Currency;
 import co.invest72.financial_product.domain.DepositProduct;
 import co.invest72.financial_product.domain.FinancialProduct;
 import co.invest72.financial_product.domain.FinancialProductRepository;
@@ -36,6 +35,7 @@ import co.invest72.financial_product.presentation.dto.response.ProductCurrency;
 import co.invest72.investment.domain.interest.InterestType;
 import co.invest72.investment.domain.investment.InvestmentType;
 import co.invest72.investment.domain.tax.TaxType;
+import co.invest72.money.domain.Currency;
 import co.invest72.security.PrincipalUser;
 import co.invest72.user.domain.User;
 import source.FinancialProductDataProvider;
@@ -102,6 +102,7 @@ class FinancialProductCalculationRestControllerTest {
 			.andExpect(jsonPath("$.monthlyDetails").isArray())
 			.andExpect(jsonPath("$.yearlyDetails").isArray())
 			.andExpect(jsonPath("$.productCurrency.code").value(productCurrency.getCode()))
+			.andExpect(jsonPath("$.productCurrency.country").value(productCurrency.getCountry()))
 			.andExpect(jsonPath("$.productCurrency.name").value(productCurrency.getName()))
 			.andDo(MockMvcResultHandlers.print());
 	}
@@ -141,6 +142,7 @@ class FinancialProductCalculationRestControllerTest {
 			.andExpect(jsonPath("$.monthlyDetails").isArray())
 			.andExpect(jsonPath("$.yearlyDetails").isArray())
 			.andExpect(jsonPath("$.productCurrency.code").value(productCurrency.getCode()))
+			.andExpect(jsonPath("$.productCurrency.country").value(productCurrency.getCountry()))
 			.andExpect(jsonPath("$.productCurrency.name").value(productCurrency.getName()))
 			.andDo(MockMvcResultHandlers.print());
 	}
@@ -179,6 +181,7 @@ class FinancialProductCalculationRestControllerTest {
 			.andExpect(jsonPath("$.monthlyDetails").isArray())
 			.andExpect(jsonPath("$.yearlyDetails").isArray())
 			.andExpect(jsonPath("$.productCurrency.code").value(productCurrency.getCode()))
+			.andExpect(jsonPath("$.productCurrency.country").value(productCurrency.getCountry()))
 			.andExpect(jsonPath("$.productCurrency.name").value(productCurrency.getName()))
 			.andDo(MockMvcResultHandlers.print());
 	}
@@ -206,6 +209,7 @@ class FinancialProductCalculationRestControllerTest {
 			.andExpect(jsonPath("$.monthlyDetails").isArray())
 			.andExpect(jsonPath("$.yearlyDetails").isArray())
 			.andExpect(jsonPath("$.productCurrency.code").value(productCurrency.getCode()))
+			.andExpect(jsonPath("$.productCurrency.country").value(productCurrency.getCountry()))
 			.andExpect(jsonPath("$.productCurrency.name").value(productCurrency.getName()))
 			.andDo(MockMvcResultHandlers.print());
 	}
@@ -233,6 +237,7 @@ class FinancialProductCalculationRestControllerTest {
 			.andExpect(jsonPath("$.monthlyDetails").isArray())
 			.andExpect(jsonPath("$.yearlyDetails").isArray())
 			.andExpect(jsonPath("$.productCurrency.code").value(productCurrency.getCode()))
+			.andExpect(jsonPath("$.productCurrency.country").value(productCurrency.getCountry()))
 			.andExpect(jsonPath("$.productCurrency.name").value(productCurrency.getName()))
 			.andDo(MockMvcResultHandlers.print());
 	}

--- a/src/test/java/co/invest72/financial_product/presentation/FinancialProductRestControllerTest.java
+++ b/src/test/java/co/invest72/financial_product/presentation/FinancialProductRestControllerTest.java
@@ -27,7 +27,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import co.invest72.common.time.LocalDateProvider;
-import co.invest72.money.domain.Currency;
 import co.invest72.financial_product.domain.FinancialProduct;
 import co.invest72.financial_product.domain.FinancialProductRepository;
 import co.invest72.financial_product.domain.IdGenerator;
@@ -39,6 +38,7 @@ import co.invest72.financial_product.presentation.dto.response.ProductCurrency;
 import co.invest72.investment.domain.interest.InterestType;
 import co.invest72.investment.domain.investment.InvestmentType;
 import co.invest72.investment.domain.tax.TaxType;
+import co.invest72.money.domain.Currency;
 import co.invest72.security.PrincipalUser;
 import co.invest72.user.domain.User;
 import co.invest72.user.infrastructure.UserIdGenerator;
@@ -287,6 +287,7 @@ class FinancialProductRestControllerTest {
 			.andExpect(jsonPath("$.progress").value(1.0))
 			.andExpect(jsonPath("$.remainingDays").value(0))
 			.andExpect(jsonPath("$.productCurrency.code").value(productCurrency.getCode()))
+			.andExpect(jsonPath("$.productCurrency.country").value(productCurrency.getCountry()))
 			.andExpect(jsonPath("$.productCurrency.name").value(productCurrency.getName()));
 	}
 
@@ -319,6 +320,7 @@ class FinancialProductRestControllerTest {
 			.andExpect(jsonPath("$.progress").value(0.16))
 			.andExpect(jsonPath("$.remainingDays").value(308))
 			.andExpect(jsonPath("$.productCurrency.code").value(productCurrency.getCode()))
+			.andExpect(jsonPath("$.productCurrency.country").value(productCurrency.getCountry()))
 			.andExpect(jsonPath("$.productCurrency.name").value(productCurrency.getName()));
 
 	}
@@ -354,6 +356,7 @@ class FinancialProductRestControllerTest {
 			.andExpect(jsonPath("$.remainingDays").value(308))
 			.andExpect(jsonPath("$.paymentDay").value(15))
 			.andExpect(jsonPath("$.productCurrency.code").value(productCurrency.getCode()))
+			.andExpect(jsonPath("$.productCurrency.country").value(productCurrency.getCountry()))
 			.andExpect(jsonPath("$.productCurrency.name").value(productCurrency.getName()));
 	}
 


### PR DESCRIPTION
## 구현한것
- ProductCurrency 클래스에 country 필드를 추가하고 name 필드에는 "통화 단위 이름"을 저장하도록 변경
  - 예를 들어 기존 name 값이 "한국 원"이라면 ProductCurrency 객체의 필드값 country="한국", name="원"이 저장되도록 변경
  - 도메인 객체인 Currency.name 필드는 기존 "한국 원"이 저장되도록 유지