### PR TITLE
[fix] 소셜 로그인 실패 핸들링 구현

### DIFF
--- a/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
+++ b/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
@@ -1,0 +1,7 @@
+package co.invest72.security;
+
+public class AuthorizedRedirectUriChecker {
+	public boolean isAuthorizedRedirectUri(String uri) {
+		return false;
+	}
+}

--- a/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
+++ b/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
@@ -1,7 +1,23 @@
 package co.invest72.security;
 
+import java.net.URI;
+import java.util.List;
+
 public class AuthorizedRedirectUriChecker {
+
+	private final List<String> allowedOrigins;
+
+	public AuthorizedRedirectUriChecker(List<String> allowedOrigins) {
+		this.allowedOrigins = allowedOrigins;
+	}
+
 	public boolean check(String uri) {
-		return false;
+		URI clientRedirectUri = URI.create(uri);
+		return allowedOrigins.stream()
+			.anyMatch(authorizedRedirectUri -> {
+				URI authorizedURI = URI.create(authorizedRedirectUri);
+				return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+					&& authorizedURI.getPort() == clientRedirectUri.getPort();
+			});
 	}
 }

--- a/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
+++ b/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
@@ -2,7 +2,11 @@ package co.invest72.security;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class AuthorizedRedirectUriChecker {
 
 	private final List<String> allowedOrigins;
@@ -12,14 +16,29 @@ public class AuthorizedRedirectUriChecker {
 	}
 
 	public boolean check(String uri) {
-		URI clientRedirectUri = URI.create(uri);
+		return createURI(uri)
+			.filter(this::checkUri)
+			.isPresent();
+	}
+
+	private Optional<URI> createURI(String uri) {
+		try {
+			URI clientRedirectUri = URI.create(uri);
+			return Optional.of(clientRedirectUri);
+		} catch (NullPointerException | IllegalArgumentException e) {
+			log.warn("invalid uri : {}, uri= {}", e.getMessage(), uri);
+			return Optional.empty();
+		}
+	}
+
+	private boolean checkUri(URI uri) {
 		return allowedOrigins.stream()
 			.anyMatch(authorizedRedirectUri -> {
 				URI authorizedURI = URI.create(authorizedRedirectUri);
 				return
-					authorizedURI.getScheme().equalsIgnoreCase(clientRedirectUri.getScheme())
-						&& authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
-						&& authorizedURI.getPort() == clientRedirectUri.getPort();
+					authorizedURI.getScheme().equalsIgnoreCase(uri.getScheme())
+						&& authorizedURI.getHost().equalsIgnoreCase(uri.getHost())
+						&& authorizedURI.getPort() == uri.getPort();
 			});
 	}
 }

--- a/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
+++ b/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
@@ -1,7 +1,7 @@
 package co.invest72.security;
 
 public class AuthorizedRedirectUriChecker {
-	public boolean isAuthorizedRedirectUri(String uri) {
+	public boolean check(String uri) {
 		return false;
 	}
 }

--- a/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
+++ b/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
@@ -20,7 +20,7 @@ public class AuthorizedRedirectUriChecker {
 			.filter(this::checkUri)
 			.isPresent();
 	}
-
+	
 	private Optional<URI> createURI(String uri) {
 		try {
 			URI clientRedirectUri = URI.create(uri);
@@ -31,14 +31,14 @@ public class AuthorizedRedirectUriChecker {
 		}
 	}
 
-	private boolean checkUri(URI uri) {
+	private boolean checkUri(URI clientURI) {
 		return allowedOrigins.stream()
-			.anyMatch(authorizedRedirectUri -> {
-				URI authorizedURI = URI.create(authorizedRedirectUri);
-				return
-					authorizedURI.getScheme().equalsIgnoreCase(uri.getScheme())
-						&& authorizedURI.getHost().equalsIgnoreCase(uri.getHost())
-						&& authorizedURI.getPort() == uri.getPort();
-			});
+			.anyMatch(authorizedRedirectUri ->
+				createURI(authorizedRedirectUri)
+					.filter(authURI -> authURI.getScheme().equals(clientURI.getScheme()))
+					.filter(authURI -> authURI.getHost().equalsIgnoreCase(clientURI.getHost()))
+					.filter(authURI -> authURI.getPort() == clientURI.getPort())
+					.isPresent()
+			);
 	}
 }

--- a/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
+++ b/src/main/java/co/invest72/security/AuthorizedRedirectUriChecker.java
@@ -16,8 +16,10 @@ public class AuthorizedRedirectUriChecker {
 		return allowedOrigins.stream()
 			.anyMatch(authorizedRedirectUri -> {
 				URI authorizedURI = URI.create(authorizedRedirectUri);
-				return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
-					&& authorizedURI.getPort() == clientRedirectUri.getPort();
+				return
+					authorizedURI.getScheme().equalsIgnoreCase(clientRedirectUri.getScheme())
+						&& authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+						&& authorizedURI.getPort() == clientRedirectUri.getPort();
 			});
 	}
 }

--- a/src/main/java/co/invest72/security/CustomOidcUserService.java
+++ b/src/main/java/co/invest72/security/CustomOidcUserService.java
@@ -27,7 +27,6 @@ public class CustomOidcUserService extends OidcUserService {
 		String providerId = oidcUser.getSubject(); // 구글의 sub값
 
 		User user = userRepository.findByProviderId(providerId).orElseGet(() -> saveNewUser(oidcUser, providerId));
-
 		return new PrincipalUser(user, oidcUser.getAttributes(), oidcUser.getIdToken(), oidcUser.getUserInfo());
 	}
 

--- a/src/main/java/co/invest72/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/co/invest72/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,45 @@
+package co.invest72.security;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository
+	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirectUri";
+	private static final String OAUTH2_AUTH_REQUEST_NAME = "oauth2_auth_request";
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		return (OAuth2AuthorizationRequest)request.getSession().getAttribute(OAUTH2_AUTH_REQUEST_NAME);
+	}
+
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+		HttpServletResponse response) {
+		if (authorizationRequest == null) {
+			request.getSession().removeAttribute(OAUTH2_AUTH_REQUEST_NAME);
+			request.getSession().removeAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
+			return;
+		}
+
+		// 세션에 인증 요청 정보 저장
+		request.getSession().setAttribute(OAUTH2_AUTH_REQUEST_NAME, authorizationRequest);
+
+		// 쿼리 파라미터로 넘어온 redirect_url을 세션에 저장
+		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+		if (redirectUriAfterLogin != null && !redirectUriAfterLogin.isBlank()) {
+			request.getSession().setAttribute(REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin);
+		}
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+		HttpServletResponse response) {
+		return this.loadAuthorizationRequest(request);
+	}
+}

--- a/src/main/java/co/invest72/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/co/invest72/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Component;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
+@Slf4j
 public class HttpCookieOAuth2AuthorizationRequestRepository
 	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirectUri";
@@ -40,6 +42,10 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 	@Override
 	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
 		HttpServletResponse response) {
-		return this.loadAuthorizationRequest(request);
+		OAuth2AuthorizationRequest authorizationRequest = this.loadAuthorizationRequest(request);
+		if (authorizationRequest != null) {
+			request.getSession().removeAttribute(OAUTH2_AUTH_REQUEST_NAME);
+		}
+		return authorizationRequest;
 	}
 }

--- a/src/main/java/co/invest72/security/HttpSessionOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/co/invest72/security/HttpSessionOAuth2AuthorizationRequestRepository.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class HttpSessionOAuth2AuthorizationRequestRepository
 	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
-	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirectUri";
+	public static final String REDIRECT_URI_PARAM_SESSION_NAME = "redirectUri";
 	private static final String OAUTH2_AUTH_REQUEST_NAME = "oauth2_auth_request";
 
 	@Override
@@ -25,7 +25,7 @@ public class HttpSessionOAuth2AuthorizationRequestRepository
 		HttpServletResponse response) {
 		if (authorizationRequest == null) {
 			request.getSession().removeAttribute(OAUTH2_AUTH_REQUEST_NAME);
-			request.getSession().removeAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
+			request.getSession().removeAttribute(REDIRECT_URI_PARAM_SESSION_NAME);
 			return;
 		}
 
@@ -33,9 +33,9 @@ public class HttpSessionOAuth2AuthorizationRequestRepository
 		request.getSession().setAttribute(OAUTH2_AUTH_REQUEST_NAME, authorizationRequest);
 
 		// 쿼리 파라미터로 넘어온 redirect_url을 세션에 저장
-		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_SESSION_NAME);
 		if (redirectUriAfterLogin != null && !redirectUriAfterLogin.isBlank()) {
-			request.getSession().setAttribute(REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin);
+			request.getSession().setAttribute(REDIRECT_URI_PARAM_SESSION_NAME, redirectUriAfterLogin);
 		}
 	}
 

--- a/src/main/java/co/invest72/security/HttpSessionOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/co/invest72/security/HttpSessionOAuth2AuthorizationRequestRepository.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
-public class HttpCookieOAuth2AuthorizationRequestRepository
+public class HttpSessionOAuth2AuthorizationRequestRepository
 	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirectUri";
 	private static final String OAUTH2_AUTH_REQUEST_NAME = "oauth2_auth_request";

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
@@ -25,10 +25,10 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException {
-		// 세션에 저장해둔 redirect_url 가져오기
+		// 세션에 저장해둔 redirect_uri 가져오기
 		String targetUrl = (String)request.getSession().getAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
 
-		// 1. 화이트리스트 검증 로직 추가
+		// 화이트리스트 검증 로직 추가
 		if (targetUrl != null && !isAuthorizedRedirectUri(targetUrl)) {
 			log.warn("비인가 리다이렉트 시도 차단: {}", targetUrl);
 			targetUrl = LOGIN_URL; // 안전하지 않은 주소일 경우 백엔드 기본 로그인으로 강제 설정

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
@@ -1,6 +1,6 @@
 package co.invest72.security;
 
-import static co.invest72.security.HttpCookieOAuth2AuthorizationRequestRepository.*;
+import static co.invest72.security.HttpSessionOAuth2AuthorizationRequestRepository.*;
 
 import java.io.IOException;
 import java.net.URLEncoder;

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
@@ -26,7 +26,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 		log.warn("Failed Authentication : {}", exception.getMessage(), exception);
 
 		// 세션에 저장해둔 redirect_uri 가져오기
-		String targetUrl = (String)request.getSession().getAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
+		String targetUrl = (String)request.getSession().getAttribute(REDIRECT_URI_PARAM_SESSION_NAME);
 
 		// 화이트리스트 검증 로직 추가
 		if (targetUrl != null && !checker.check(targetUrl)) {
@@ -54,7 +54,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 			: targetUrl + "?error=" + encodedMessage;
 
 		// 사용한 세션 데이터 삭제 (Clean up)
-		request.getSession().removeAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
+		request.getSession().removeAttribute(REDIRECT_URI_PARAM_SESSION_NAME);
 
 		getRedirectStrategy().sendRedirect(request, response, redirectUrl);
 	}

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
@@ -1,20 +1,70 @@
 package co.invest72.security;
 
+import static co.invest72.security.HttpCookieOAuth2AuthorizationRequestRepository.*;
+
 import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
-import org.springframework.stereotype.Component;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-@Component
+@Slf4j
+@RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+	private static final String LOGIN_URL = "/login";
+	private final List<String> allowedOrigins;
+
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException {
-		String targetUrl = "http://localhost:3000/login?error=" + exception.getLocalizedMessage();
-		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+		// 세션에 저장해둔 redirect_url 가져오기
+		String targetUrl = (String)request.getSession().getAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
+
+		// 1. 화이트리스트 검증 로직 추가
+		if (targetUrl != null && !isAuthorizedRedirectUri(targetUrl)) {
+			log.warn("비인가 리다이렉트 시도 차단: {}", targetUrl);
+			targetUrl = LOGIN_URL; // 안전하지 않은 주소일 경우 백엔드 기본 로그인으로 강제 설정
+		}
+
+		// 메시지 인코딩
+		String message = (exception.getLocalizedMessage() != null)
+			? exception.getLocalizedMessage()
+			: "Authentication failed";
+		String encodedMessage = URLEncoder.encode(message, StandardCharsets.UTF_8);
+
+		if (targetUrl == null || targetUrl.isBlank()) {
+			// 저장된 주소가 없다면 기본 백엔드 로그인 페이지로
+			targetUrl = LOGIN_URL;
+		} else {
+			targetUrl = targetUrl + LOGIN_URL;
+		}
+
+		// 에러 파라미터 결합 (기존 파라미터 유무 체크)
+		String redirectUrl = targetUrl.contains("?")
+			? targetUrl + "&error=" + encodedMessage
+			: targetUrl + "?error=" + encodedMessage;
+
+		// 사용한 세션 데이터 삭제 (Clean up)
+		request.getSession().removeAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
+
+		getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+	}
+
+	private boolean isAuthorizedRedirectUri(String uri) {
+		URI clientRedirectUri = URI.create(uri);
+		return allowedOrigins.stream()
+			.anyMatch(authorizedRedirectUri -> {
+				URI authorizedURI = URI.create(authorizedRedirectUri);
+				return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+					&& authorizedURI.getPort() == clientRedirectUri.getPort();
+			});
 	}
 }

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,20 @@
+package co.invest72.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+		String targetUrl = "http://localhost:3000/login?error=" + exception.getLocalizedMessage();
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+}

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
@@ -3,10 +3,8 @@ package co.invest72.security;
 import static co.invest72.security.HttpCookieOAuth2AuthorizationRequestRepository.*;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
@@ -20,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 	private static final String LOGIN_URL = "/login";
-	private final List<String> allowedOrigins;
+	private final AuthorizedRedirectUriChecker checker;
 
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -31,7 +29,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 		String targetUrl = (String)request.getSession().getAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
 
 		// 화이트리스트 검증 로직 추가
-		if (targetUrl != null && !isAuthorizedRedirectUri(targetUrl)) {
+		if (targetUrl != null && !checker.check(targetUrl)) {
 			log.warn("비인가 리다이렉트 시도 차단: {}", targetUrl);
 			targetUrl = null; // 안전하지 않은 주소일 경우 백엔드 기본 로그인으로 강제 설정
 			log.debug("targetUrl : {}", targetUrl);
@@ -59,15 +57,5 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 		request.getSession().removeAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
 
 		getRedirectStrategy().sendRedirect(request, response, redirectUrl);
-	}
-
-	private boolean isAuthorizedRedirectUri(String uri) {
-		URI clientRedirectUri = URI.create(uri);
-		return allowedOrigins.stream()
-			.anyMatch(authorizedRedirectUri -> {
-				URI authorizedURI = URI.create(authorizedRedirectUri);
-				return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
-					&& authorizedURI.getPort() == clientRedirectUri.getPort();
-			});
 	}
 }

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
@@ -25,6 +25,8 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException {
+		log.warn("Failed Authentication : {}", exception.getMessage(), exception);
+
 		// 세션에 저장해둔 redirect_uri 가져오기
 		String targetUrl = (String)request.getSession().getAttribute(REDIRECT_URI_PARAM_COOKIE_NAME);
 
@@ -37,7 +39,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 		// 메시지 인코딩
 		String message = (exception.getLocalizedMessage() != null)
 			? exception.getLocalizedMessage()
-			: "Authentication failed";
+			: "Failed Authentication";
 		String encodedMessage = URLEncoder.encode(message, StandardCharsets.UTF_8);
 
 		if (targetUrl == null || targetUrl.isBlank()) {

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationFailureHandler.java
@@ -33,7 +33,8 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 		// 화이트리스트 검증 로직 추가
 		if (targetUrl != null && !isAuthorizedRedirectUri(targetUrl)) {
 			log.warn("비인가 리다이렉트 시도 차단: {}", targetUrl);
-			targetUrl = LOGIN_URL; // 안전하지 않은 주소일 경우 백엔드 기본 로그인으로 강제 설정
+			targetUrl = null; // 안전하지 않은 주소일 경우 백엔드 기본 로그인으로 강제 설정
+			log.debug("targetUrl : {}", targetUrl);
 		}
 
 		// 메시지 인코딩

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationSuccessHandler.java
@@ -35,7 +35,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 			csrfToken.getToken();
 		}
 
-		// redirectUri는 프론트에서 로그인 성공 후 리다이렉트할 URL입니다. 예를 들어, "http://localhost:3000/login-success"와 같은 URL이 될 수 있습니다.
+		// redirectUri는 프론트에서 로그인 성공 후 리다이렉트할 URL입니다. 예를 들어, "http://localhost:3000"와 같은 URL이 될 수 있습니다.
 		String targetUrl = UriComponentsBuilder.fromUriString(redirectUri).build().toUriString();
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);
 	}

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationSuccessHandler.java
@@ -7,19 +7,20 @@ import java.io.IOException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.stereotype.Component;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
-@Component
 @Slf4j
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-	public OAuth2AuthenticationSuccessHandler() {
+	private final AuthorizedRedirectUriChecker authorizedRedirectUriChecker;
+
+	public OAuth2AuthenticationSuccessHandler(AuthorizedRedirectUriChecker authorizedRedirectUriChecker) {
 		super("/");
+		this.authorizedRedirectUriChecker = authorizedRedirectUriChecker;
 	}
 
 	@Override
@@ -33,7 +34,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		}
 
 		String targetUrl = (String)request.getSession().getAttribute(REDIRECT_URI_PARAM_SESSION_NAME);
-		if (targetUrl == null || targetUrl.isBlank()) {
+		if (targetUrl == null || targetUrl.isBlank() || !authorizedRedirectUriChecker.check(targetUrl)) {
 			// 백엔드 서버의 루트 경로로 리다이렉트
 			targetUrl = getDefaultTargetUrl();
 		}

--- a/src/main/java/co/invest72/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/co/invest72/security/OAuth2AuthenticationSuccessHandler.java
@@ -1,13 +1,13 @@
 package co.invest72.security;
 
+import static co.invest72.security.HttpSessionOAuth2AuthorizationRequestRepository.*;
+
 import java.io.IOException;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,12 +17,9 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Slf4j
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-	private final String redirectUri;
 
-	public OAuth2AuthenticationSuccessHandler(
-		@Value("${app.oauth2.authorized-redirect-uri}") String redirectUri) {
+	public OAuth2AuthenticationSuccessHandler() {
 		super("/");
-		this.redirectUri = redirectUri;
 	}
 
 	@Override
@@ -35,8 +32,17 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 			csrfToken.getToken();
 		}
 
-		// redirectUri는 프론트에서 로그인 성공 후 리다이렉트할 URL입니다. 예를 들어, "http://localhost:3000"와 같은 URL이 될 수 있습니다.
-		String targetUrl = UriComponentsBuilder.fromUriString(redirectUri).build().toUriString();
+		String targetUrl = (String)request.getSession().getAttribute(REDIRECT_URI_PARAM_SESSION_NAME);
+		if (targetUrl == null || targetUrl.isBlank()) {
+			// 백엔드 서버의 루트 경로로 리다이렉트
+			targetUrl = getDefaultTargetUrl();
+		}
+		log.info("success login, targetUrl={}", targetUrl);
+
+		// clean up user session data
+		request.getSession().removeAttribute(REDIRECT_URI_PARAM_SESSION_NAME);
+
+		// redirect
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);
 	}
 }

--- a/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
@@ -63,7 +63,9 @@ public class OAuth2LoginSecurityConfig {
 			.oauth2Login(oauth2 -> oauth2
 				.userInfoEndpoint(userInfo -> userInfo
 					.oidcUserService(customOidcUserService))
-				.successHandler(successHandler))
+				.successHandler(successHandler)
+				.failureHandler(oAuth2AuthenticationFailureHandler())
+			)
 			.logout(logout -> logout
 				.logoutUrl("/api/v1/auth/logout")
 				.logoutSuccessHandler((request, response, authentication) ->
@@ -98,5 +100,10 @@ public class OAuth2LoginSecurityConfig {
 			cookie.sameSite("Lax");
 		});
 		return repository;
+	}
+
+	@Bean
+	public OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler() {
+		return new OAuth2AuthenticationFailureHandler();
 	}
 }

--- a/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
@@ -35,6 +36,7 @@ public class OAuth2LoginSecurityConfig {
 	private final CustomOidcUserService customOidcUserService;
 	private final CorsConfigurationProperties corsConfigurationProperties;
 	private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+	private final AuthenticationEntryPoint authenticationEntryPoint;
 
 	@Value("${app.domain}")
 	private String csrfCookieDomain;
@@ -81,6 +83,9 @@ public class OAuth2LoginSecurityConfig {
 					response.setStatus(HttpServletResponse.SC_OK)
 				)
 				.invalidateHttpSession(true) // 세션 무효화
+			)
+			.exceptionHandling(configurer ->
+				configurer.authenticationEntryPoint(authenticationEntryPoint)
 			);
 		return http.build();
 	}

--- a/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
@@ -32,7 +32,6 @@ import lombok.RequiredArgsConstructor;
 @EnableConfigurationProperties(CorsConfigurationProperties.class)
 public class OAuth2LoginSecurityConfig {
 
-	private final OAuth2AuthenticationSuccessHandler successHandler;
 	private final CustomOidcUserService customOidcUserService;
 	private final CorsConfigurationProperties corsConfigurationProperties;
 	private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
@@ -43,6 +42,8 @@ public class OAuth2LoginSecurityConfig {
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		AuthorizedRedirectUriChecker authorizedRedirectUriChecker = authorizedRedirectUriChecker();
+
 		// 필터 등록
 		http.addFilterAfter(new CsrfCookieFilter(), BasicAuthenticationFilter.class); // 인증 필터 이후에 실행
 
@@ -74,8 +75,8 @@ public class OAuth2LoginSecurityConfig {
 					authorization -> authorization.authorizationRequestRepository(authorizationRequestRepository))
 				.userInfoEndpoint(userInfo -> userInfo
 					.oidcUserService(customOidcUserService))
-				.successHandler(successHandler)
-				.failureHandler(oAuth2AuthenticationFailureHandler())
+				.successHandler(oAuth2AuthenticationSuccessHandler(authorizedRedirectUriChecker))
+				.failureHandler(oAuth2AuthenticationFailureHandler(authorizedRedirectUriChecker))
 			)
 			.logout(logout -> logout
 				.logoutUrl("/api/v1/auth/logout")
@@ -117,13 +118,19 @@ public class OAuth2LoginSecurityConfig {
 	}
 
 	@Bean
-	public OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler() {
-		return new OAuth2AuthenticationFailureHandler(authorizedRedirectUriChecker());
+	public OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler(AuthorizedRedirectUriChecker checker) {
+		return new OAuth2AuthenticationFailureHandler(checker);
 	}
 
 	@Bean
 	public AuthorizedRedirectUriChecker authorizedRedirectUriChecker() {
 		List<String> allowedOrigins = corsConfigurationProperties.getAllowedOrigins();
 		return new AuthorizedRedirectUriChecker(allowedOrigins);
+	}
+
+	@Bean
+	public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler(
+		AuthorizedRedirectUriChecker checker) {
+		return new OAuth2AuthenticationSuccessHandler(checker);
 	}
 }

--- a/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
@@ -2,6 +2,8 @@ package co.invest72.security;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.*;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +12,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
@@ -30,6 +34,8 @@ public class OAuth2LoginSecurityConfig {
 	private final OAuth2AuthenticationSuccessHandler successHandler;
 	private final CustomOidcUserService customOidcUserService;
 	private final CorsConfigurationProperties corsConfigurationProperties;
+	private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+
 	@Value("${app.domain}")
 	private String csrfCookieDomain;
 
@@ -61,6 +67,9 @@ public class OAuth2LoginSecurityConfig {
 					.requestMatchers(HttpMethod.OPTIONS).permitAll()
 					.anyRequest().authenticated())
 			.oauth2Login(oauth2 -> oauth2
+				.loginPage("/login")
+				.authorizationEndpoint(
+					authorization -> authorization.authorizationRequestRepository(authorizationRequestRepository))
 				.userInfoEndpoint(userInfo -> userInfo
 					.oidcUserService(customOidcUserService))
 				.successHandler(successHandler)
@@ -104,6 +113,7 @@ public class OAuth2LoginSecurityConfig {
 
 	@Bean
 	public OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler() {
-		return new OAuth2AuthenticationFailureHandler();
+		List<String> allowedOrigins = corsConfigurationProperties.getAllowedOrigins();
+		return new OAuth2AuthenticationFailureHandler(allowedOrigins);
 	}
 }

--- a/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/co/invest72/security/OAuth2LoginSecurityConfig.java
@@ -118,7 +118,12 @@ public class OAuth2LoginSecurityConfig {
 
 	@Bean
 	public OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler() {
+		return new OAuth2AuthenticationFailureHandler(authorizedRedirectUriChecker());
+	}
+
+	@Bean
+	public AuthorizedRedirectUriChecker authorizedRedirectUriChecker() {
 		List<String> allowedOrigins = corsConfigurationProperties.getAllowedOrigins();
-		return new OAuth2AuthenticationFailureHandler(allowedOrigins);
+		return new AuthorizedRedirectUriChecker(allowedOrigins);
 	}
 }

--- a/src/main/java/co/invest72/security/OAuthAuthenticationEntryPoint.java
+++ b/src/main/java/co/invest72/security/OAuthAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package co.invest72.security;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuthAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+		log.warn("unauthenticated access : {}", authException.getMessage());
+
+		// Set Response Header
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		// set error message
+		Map<String, Object> body = new HashMap<>();
+		body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+		body.put("error", "Unauthorized");
+		body.put("message", "로그인이 필요한 서비스입니다.");
+		body.put("path", request.getServletPath());
+
+		// convert to json
+		response.getWriter().write(objectMapper.writeValueAsString(body));
+	}
+}

--- a/src/main/java/co/invest72/security/presentation/LoginController.java
+++ b/src/main/java/co/invest72/security/presentation/LoginController.java
@@ -1,0 +1,16 @@
+package co.invest72.security.presentation;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@Slf4j
+public class LoginController {
+
+	@GetMapping("/login")
+	public String loginPage() {
+		return "login";
+	}
+}

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>로그인 - invest72</title>
+    <style>
+        body {
+            font-family: 'Pretendard', -apple-system, sans-serif;
+            background-color: #f5f7f9;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+
+        .login-card {
+            background: white;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+            width: 100%;
+            max-width: 400px;
+            text-align: center;
+        }
+
+        .logo {
+            font-size: 24px;
+            font-weight: bold;
+            color: #4285F4;
+            margin-bottom: 10px;
+        }
+
+        h1 {
+            font-size: 18px;
+            color: #333;
+            margin-bottom: 30px;
+        }
+
+        /* 에러 메시지 스타일 */
+        .error-container {
+            background-color: #fff5f5;
+            color: #e53e3e;
+            border: 1px solid #feb2b2;
+            padding: 12px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            font-size: 14px;
+            display: none; /* 기본적으로 숨김 */
+        }
+
+        /* 구글 공식 가이드라인 버튼 스타일 */
+        .gsi-material-button {
+            background-color: white;
+            border: 1px solid #dadce0;
+            border-radius: 4px;
+            box-sizing: border-box;
+            color: #3c4043;
+            cursor: pointer;
+            font-family: 'Google Sans', arial, sans-serif;
+            font-size: 14px;
+            height: 40px;
+            letter-spacing: 0.25px;
+            outline: none;
+            overflow: hidden;
+            padding: 0 12px;
+            position: relative;
+            text-align: center;
+            transition: background-color .218s, border-color .218s, box-shadow .218s;
+            vertical-align: middle;
+            white-space: nowrap;
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-decoration: none;
+        }
+
+        .gsi-material-button:hover {
+            background-color: #f7f8f8;
+            border-color: #d2dce0;
+            box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
+        }
+
+        .gsi-material-button-icon {
+            height: 18px;
+            margin-right: 10px;
+            min-width: 18px;
+            width: 18px;
+        }
+
+        .gsi-material-button-content-wrapper {
+            display: flex;
+        }
+    </style>
+</head>
+<body>
+
+<div class="login-card">
+    <div class="logo">invest72</div>
+    <h1>서비스 이용을 위해 로그인해주세요</h1>
+
+    <!-- 에러 발생 시 출력되는 영역 -->
+    <div id="error-box" class="error-container">
+        <span id="error-message"></span>
+    </div>
+
+    <!-- 구글 소셜 로그인 버튼 -->
+    <!-- href 주소는 사용자의 백엔드 설정에 맞춰 작성 -->
+    <a href="/oauth2/authorization/google" class="gsi-material-button">
+        <div class="gsi-material-button-content-wrapper">
+            <div class="gsi-material-button-icon">
+                <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" style="display: block;">
+                    <path fill="#EA4335"
+                          d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+                    <path fill="#4285F4"
+                          d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+                    <path fill="#FBBC05"
+                          d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+                    <path fill="#34A853"
+                          d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+                </svg>
+            </div>
+            <span class="gsi-material-button-contents">Google 계정으로 계속하기</span>
+        </div>
+    </a>
+</div>
+
+<script>
+    // URL 파라미터에서 error를 읽어 화면에 표시하는 스크립트
+    window.onload = function () {
+        const urlParams = new URLSearchParams(window.location.search);
+        const error = urlParams.get('error');
+
+        if (error) {
+            const errorBox = document.getElementById('error-box');
+            const errorMsg = document.getElementById('error-message');
+
+            errorBox.style.display = 'block';
+
+            // error가 true로 넘어올 경우와 상세 메시지로 넘어올 경우 분기 처리
+            if (error === 'true') {
+                errorMsg.innerText = "로그인 도중 오류가 발생했습니다.";
+            } else {
+                errorMsg.innerText = decodeURIComponent(error);
+            }
+        }
+    }
+</script>
+
+</body>
+</html>

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -6,6 +6,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class AuthorizedRedirectUriCheckerTest {
 
@@ -17,9 +19,9 @@ class AuthorizedRedirectUriCheckerTest {
 		checker = new AuthorizedRedirectUriChecker(allowedOrigins);
 	}
 
-	@DisplayName("URI 검사")
+	@DisplayName("URI 검사 - 프로토콜, 호스트, 포트가 대소문자 관계없이 일치하면 true를 반환해야 한다")
 	@Test
-	void check() {
+	void check_whenOriginIsMatched_thenReturnTrue() {
 		// given
 		String uri = "http://localhost:3000";
 		// when
@@ -28,33 +30,10 @@ class AuthorizedRedirectUriCheckerTest {
 		Assertions.assertThat(actual).isTrue();
 	}
 
-	@DisplayName("URI 검사 - 출처가 프로토콜이 다르면 false를 반환하여야 한다")
-	@Test
-	void check_whenProtocolIsDiff_thenReturnFalse() {
-		// given
-		String uri = "https://localhost:3000";
-		// when
-		boolean actual = checker.check(uri);
-		// then
-		Assertions.assertThat(actual).isFalse();
-	}
-
-	@DisplayName("URI 검사 - 출처가 포트가 다르면 false를 반환하여야 한다")
-	@Test
-	void check_whenPortIsDiff_thenReturnFalse() {
-		// given
-		String uri = "https://localhost:4000";
-		// when
-		boolean actual = checker.check(uri);
-		// then
-		Assertions.assertThat(actual).isFalse();
-	}
-
-	@DisplayName("URI 검사 - 호스트가 다르면 false를 반환하여야 한다")
-	@Test
-	void check_whenHostIsDiff_thenReturnFalse() {
-		// given
-		String uri = "http://hacker.com:3000";
+	@DisplayName("URI 검사 - 프로토콜, 호스트, 포트가 다르면 false를 반환해야 한다")
+	@ParameterizedTest
+	@ValueSource(strings = {"https://localhost:3000", "http://hacker.com:3000", "http://localhost:4000"})
+	void check_whenOriginIsDiff_thenReturnFalse(String uri) {
 		// when
 		boolean actual = checker.check(uri);
 		// then

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -14,4 +14,16 @@ class AuthorizedRedirectUriCheckerTest {
 		// then
 		Assertions.assertThat(checker).isNotNull();
 	}
+
+	@DisplayName("URI 검사")
+	@Test
+	void check() {
+		// given
+		AuthorizedRedirectUriChecker checker = new AuthorizedRedirectUriChecker();
+		String uri = "http://localhost:3000";
+		// when
+		boolean actual = checker.check(uri);
+		// then
+		Assertions.assertThat(actual).isFalse();
+	}
 }

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -27,4 +27,26 @@ class AuthorizedRedirectUriCheckerTest {
 		// then
 		Assertions.assertThat(actual).isTrue();
 	}
+
+	@DisplayName("URI 검사 - 출처가 프로토콜이 다르면 false를 반환하여야 한다")
+	@Test
+	void check_whenProtocolIsDiff_thenReturnFalse() {
+		// given
+		String uri = "https://localhost:3000";
+		// when
+		boolean actual = checker.check(uri);
+		// then
+		Assertions.assertThat(actual).isFalse();
+	}
+
+	@DisplayName("URI 검사 - 허용되지 않는 도메인은 false를 반환하여야 한다")
+	@Test
+	void check_whenUriIsNotAllowedOrigin_thenReturnFalse() {
+		// given
+		String uri = "http://hacker.com";
+		// when
+		boolean actual = checker.check(uri);
+		// then
+		Assertions.assertThat(actual).isFalse();
+	}
 }

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -30,9 +30,10 @@ class AuthorizedRedirectUriCheckerTest {
 		Assertions.assertThat(actual).isTrue();
 	}
 
-	@DisplayName("URI 검사 - 프로토콜, 호스트, 포트가 다르면 false를 반환해야 한다")
+	@DisplayName("URI 검사 - uri가 허용되는 출처 목록에 없거나 유효하지 않은 형식이면 false를 반환해야 한다")
 	@ParameterizedTest
-	@ValueSource(strings = {"https://localhost:3000", "http://hacker.com:3000", "http://localhost:4000"})
+	@ValueSource(strings = {"https://localhost:3000", "http://hacker.com:3000", "http://localhost:4000",
+		"http", "localhost", "3000"})
 	void check_whenOriginIsDiff_thenReturnFalse(String uri) {
 		// when
 		boolean actual = checker.check(uri);

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -1,6 +1,5 @@
 package co.invest72.security;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -14,7 +13,7 @@ class AuthorizedRedirectUriCheckerTest {
 
 	@BeforeEach
 	void setUp() {
-		List<String> allowedOrigins = new ArrayList<>();
+		List<String> allowedOrigins = List.of("http://localhost:3000");
 		checker = new AuthorizedRedirectUriChecker(allowedOrigins);
 	}
 
@@ -26,6 +25,6 @@ class AuthorizedRedirectUriCheckerTest {
 		// when
 		boolean actual = checker.check(uri);
 		// then
-		Assertions.assertThat(actual).isFalse();
+		Assertions.assertThat(actual).isTrue();
 	}
 }

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -39,4 +39,15 @@ class AuthorizedRedirectUriCheckerTest {
 		// then
 		Assertions.assertThat(actual).isFalse();
 	}
+
+	@DisplayName("URI 검사 - uri가 null이면 false를 반환해야 한다")
+	@Test
+	void check_whenUriIsNull_thenReturnFalse() {
+		// given
+		String uri = null;
+		// when
+		boolean actual = checker.check(uri);
+		// then
+		Assertions.assertThat(actual).isFalse();
+	}
 }

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -1,0 +1,17 @@
+package co.invest72.security;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuthorizedRedirectUriCheckerTest {
+
+	@DisplayName("객체 생성")
+	@Test
+	void canCreated() {
+		// when
+		AuthorizedRedirectUriChecker checker = new AuthorizedRedirectUriChecker();
+		// then
+		Assertions.assertThat(checker).isNotNull();
+	}
+}

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -39,11 +39,22 @@ class AuthorizedRedirectUriCheckerTest {
 		Assertions.assertThat(actual).isFalse();
 	}
 
-	@DisplayName("URI 검사 - 허용되지 않는 도메인은 false를 반환하여야 한다")
+	@DisplayName("URI 검사 - 출처가 포트가 다르면 false를 반환하여야 한다")
 	@Test
-	void check_whenUriIsNotAllowedOrigin_thenReturnFalse() {
+	void check_whenPortIsDiff_thenReturnFalse() {
 		// given
-		String uri = "http://hacker.com";
+		String uri = "https://localhost:4000";
+		// when
+		boolean actual = checker.check(uri);
+		// then
+		Assertions.assertThat(actual).isFalse();
+	}
+
+	@DisplayName("URI 검사 - 호스트가 다르면 false를 반환하여야 한다")
+	@Test
+	void check_whenHostIsDiff_thenReturnFalse() {
+		// given
+		String uri = "http://hacker.com:3000";
 		// when
 		boolean actual = checker.check(uri);
 		// then

--- a/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
+++ b/src/test/java/co/invest72/security/AuthorizedRedirectUriCheckerTest.java
@@ -1,25 +1,27 @@
 package co.invest72.security;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class AuthorizedRedirectUriCheckerTest {
 
-	@DisplayName("객체 생성")
-	@Test
-	void canCreated() {
-		// when
-		AuthorizedRedirectUriChecker checker = new AuthorizedRedirectUriChecker();
-		// then
-		Assertions.assertThat(checker).isNotNull();
+	private AuthorizedRedirectUriChecker checker;
+
+	@BeforeEach
+	void setUp() {
+		List<String> allowedOrigins = new ArrayList<>();
+		checker = new AuthorizedRedirectUriChecker(allowedOrigins);
 	}
 
 	@DisplayName("URI 검사")
 	@Test
 	void check() {
 		// given
-		AuthorizedRedirectUriChecker checker = new AuthorizedRedirectUriChecker();
 		String uri = "http://localhost:3000";
 		// when
 		boolean actual = checker.check(uri);


### PR DESCRIPTION
## 구현한것
- 소셜 로그인 실패시 로그인 페이지로 리다이렉트 시키는 핸들러(OAuth2AuthenticationFailHandler) 구현
- 인증되지 않은 사용자가 인증이 요구되는 API 요청시 401을 응답하는 엔트리 포인트(OAuth2AuthenticationEntryPoint) 구현
- 인증 요청시 인증 요청 정보를 세션 저장하는 요청 저장소(HttpCookieOAuth2AuthorizationRequestRepository) 구현
  - 해당 저장소를 이용하여 프론트엔드(www.invest72.site)에서 소셜 로그인을 요청하다가 백엔드 단에서 구글 통신중 실패시 프론트엔드의 로그인 페이지로 이동하기 위해서 저장소를 활용함
- 백엔드 서버만의 login 페이지(html) 구현
- 백엔드 로그인 페이지로 이동하는 경로 추가(/login)
- 인증 성공 핸들러 수정
  - 기존 백엔드에서 프론트엔드 주소로 고정적으로 리다이렉션하는것이 아니라 파라미터로 받은 redirect_uri로 리다이렉션 하도록 변경